### PR TITLE
add POC server iniated client.

### DIFF
--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -101,6 +101,12 @@ func Username(u string) metaOp {
 	}
 }
 
+func HttpClient(http *http.Client) metaOp {
+	return func(c *Client) {
+		c.http = http
+	}
+}
+
 // New returns a pointer to a snap api client
 // if ver is an empty string, v1 is used by default
 func New(url, ver string, insecure bool, opts ...metaOp) (*Client, error) {

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -60,7 +60,11 @@ var (
 		Name:  "rest-auth",
 		Usage: "Enables snap's REST API authentication",
 	}
+	flWsServer = cli.StringFlag{
+		Name:  "ws-server",
+		Usage: "Address of control server",
+	}
 
 	// Flags consumed by snapd
-	Flags = []cli.Flag{flAPIDisabled, flAPIAddr, flAPIPort, flRestHTTPS, flRestCert, flRestKey, flRestAuth}
+	Flags = []cli.Flag{flAPIDisabled, flAPIAddr, flAPIPort, flRestHTTPS, flRestCert, flRestKey, flRestAuth, flWsServer}
 )

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -82,6 +82,7 @@ type Config struct {
 	RestAuth         bool   `json:"rest_auth"yaml:"rest_auth"`
 	RestAuthPassword string `json:"rest_auth_password"yaml:"rest_auth_password"`
 	portSetByConfig  bool   ``
+	WsServer         string `json:"ws_server"yaml:"ws_server"`
 }
 
 const (
@@ -105,6 +106,9 @@ const (
 						"type": "string"
 					},
 					"rest_key" : {
+						"type": "string"
+					},
+					"ws_server": {
 						"type": "string"
 					},
 					"port" : {
@@ -213,6 +217,7 @@ func New(cfg *Config) (*Server, error) {
 	s.r = httprouter.New()
 	// Use negroni to handle routes
 	s.n.UseHandler(s.r)
+
 	return s, nil
 }
 

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -524,3 +524,7 @@ func parseNamespace(ns string) []string {
 	}
 	return strings.Split(ns, "/")
 }
+
+func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	s.n.ServeHTTP(rw, r)
+}

--- a/mgmt/rest/ws_client/server/server.go
+++ b/mgmt/rest/ws_client/server/server.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"golang.org/x/net/websocket"
+	"log"
+	"net/http"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"time"
+
+	"github.com/intelsdi-x/snap/mgmt/rest/client"
+	"github.com/intelsdi-x/snap/mgmt/rest/ws_client"
+)
+
+type wsRoundTripper struct {
+	c *rpc.Client
+}
+
+func (r *wsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	reply := new(ws_client.WsClientPayload)
+	var b bytes.Buffer
+	req.Write(&b)
+	rpcReq := ws_client.WsClientPayload{Data: b.Bytes()}
+	err := r.c.Call("SnapClientOverWebsocket.Handle", rpcReq, reply)
+	if err != nil {
+		log.Fatal("SnapClientOverWebsocket.Handle error:", err)
+	}
+
+	return http.ReadResponse(bufio.NewReader(bytes.NewBuffer(reply.Data)), req)
+}
+
+func main() {
+
+	http.Handle("/ws", websocket.Handler(serve))
+	http.ListenAndServe("localhost:7000", nil)
+
+}
+
+func serve(ws *websocket.Conn) {
+	log.Printf("Handler starting")
+	c := jsonrpc.NewClient(ws)
+	hc := &http.Client{
+		Transport: &wsRoundTripper{c: c},
+	}
+	snapClient, err := client.New("http://localhost", "", true, client.HttpClient(hc))
+	if err != nil {
+		panic(err)
+	}
+
+	done := make(chan struct{})
+	go func(done chan struct{}) {
+		ticker := time.NewTicker(time.Second)
+		defer close(done)
+		for range ticker.C {
+			recv := &time.Time{}
+			sent := time.Now()
+			err := c.Call("SnapClientOverWebsocket.Heartbeat", sent, recv)
+			if err != nil {
+				log.Printf("SnapClientOverWebsocket.Heartbeat error:%s", err)
+				ticker.Stop()
+				return
+			}
+			log.Printf("Heartbeat took %s", recv.Sub(sent))
+		}
+		close(done)
+	}(done)
+
+	go func(done chan struct{}) {
+		ticker := time.NewTicker(time.Second * 5)
+		for {
+			select {
+			case <-ticker.C:
+				resp := snapClient.GetPlugins(true)
+				for _, plugin := range resp.LoadedPlugins {
+					log.Printf("found plugin %s", plugin.Name)
+				}
+			case <-done:
+				log.Printf("stopping plugin list")
+				ticker.Stop()
+				return
+			}
+		}
+	}(done)
+
+	<-done
+	log.Printf("Handler exiting")
+}

--- a/mgmt/rest/ws_client/server/server.go
+++ b/mgmt/rest/ws_client/server/server.go
@@ -7,17 +7,63 @@ import (
 	"golang.org/x/net/websocket"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+	"sync"
 	"time"
 
 	"github.com/codeskyblue/go-uuid"
+	"github.com/gorilla/mux"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
 	"github.com/intelsdi-x/snap/mgmt/rest/ws_client"
+	"github.com/urfave/negroni"
 )
 
-var sessions map[string]*Session
+type Session struct {
+	Id         string
+	Name       string
+	socket     *websocket.Conn
+	snapClient *client.Client
+	jsonrpcCli *rpc.Client
+}
+
+type SessionStore struct {
+	sessions map[string]*Session
+	sync.Mutex
+}
+
+func (s *SessionStore) Get(id string) *Session {
+	s.Lock()
+	defer s.Unlock()
+	return s.sessions[id]
+}
+
+func (s *SessionStore) Put(id string, sess *Session) {
+	s.Lock()
+	s.sessions[id] = sess
+	s.Unlock()
+}
+
+func (s *SessionStore) Delete(id string) {
+	s.Lock()
+	delete(s.sessions, id)
+	s.Unlock()
+}
+
+func (s *SessionStore) All() []*Session {
+	s.Lock()
+	currentSessions := make([]*Session, len(s.sessions))
+	i := 0
+	for _, sess := range s.sessions {
+		currentSessions[i] = sess
+		i++
+	}
+	s.Unlock()
+	return currentSessions
+}
+
+var sessionsStore *SessionStore
 
 type wsRoundTripper struct {
 	c *rpc.Client
@@ -37,28 +83,61 @@ func (r *wsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func main() {
-	sessions = make(map[string]*Session)
-	http.Handle("/ws", websocket.Handler(serveWs))
-	http.HandleFunc("/catalog", servePlugins)
-	http.ListenAndServe("localhost:7000", nil)
-
+	sessionsStore = &SessionStore{sessions: make(map[string]*Session)}
+	rtr := mux.NewRouter()
+	http.Handle("/", rtr)
+	rtr.Handle("/ws", websocket.Handler(websocketHandler))
+	rtr.PathPrefix("/v1/").HandlerFunc(proxyHandler)
+	rtr.HandleFunc("/nodes", nodesHandler)
+	n := negroni.Classic() // Includes some default middlewares
+	n.UseHandler(rtr)
+	n.Run(":7000")
 }
 
-func servePlugins(w http.ResponseWriter, r *http.Request) {
-	catalog := make([]*rbody.Metric, 0)
-	for id, sess := range sessions {
-		log.Printf("getting plugins from socket with sessionId: %s", id)
-		resp := sess.snapClient.GetMetricCatalog()
-		catalog = append(catalog, resp.Catalog...)
+func nodesHandler(w http.ResponseWriter, r *http.Request) {
+	nodes := make([]string, 0)
+	for _, sess := range sessionsStore.All() {
+		nodes = append(nodes, sess.Name)
 	}
-	body, err := json.Marshal(catalog)
+	body, err := json.Marshal(nodes)
 	if err != nil {
 		panic(err)
 	}
 	w.Write(body)
 }
 
-func serveWs(ws *websocket.Conn) {
+func proxyHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("handling proxy request")
+	query := r.URL.Query()
+	node := query.Get("proxy_node")
+
+	if node == "" {
+		w.WriteHeader(400)
+		w.Write([]byte("no proxy_node url param present."))
+		return
+	}
+
+	session := sessionsStore.Get(node)
+	if session == nil {
+		w.WriteHeader(404)
+		w.Write([]byte("Not found"))
+		return
+	}
+	// modify the URL PATH to strip out the request to the node.
+	director := func(req *http.Request) {
+		query := req.URL.Query()
+		query.Del("proxy_node")
+		req.URL.RawQuery = query.Encode()
+	}
+
+	proxy := httputil.ReverseProxy{
+		Director:  director,
+		Transport: &wsRoundTripper{c: session.jsonrpcCli},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func websocketHandler(ws *websocket.Conn) {
 	log.Printf("Handler starting")
 	c := jsonrpc.NewClient(ws)
 	hc := &http.Client{
@@ -74,21 +153,24 @@ func serveWs(ws *websocket.Conn) {
 		snapClient: snapClient,
 		jsonrpcCli: c,
 	}
-	sessions[session.Id] = session
+
+	meta := make(map[string]string)
+	err = c.Call("SnapClientOverWebsocket.Metadata", session.Id, &meta)
+	if err != nil {
+		log.Printf("SnapClientOverWebsocket.Metadata error:%s", err)
+		ws.Close()
+		return
+	}
+	session.Name = meta["name"]
+	sessionsStore.Put(session.Name, session)
+	defer sessionsStore.Delete(session.Name)
 	session.Run()
 	log.Printf("Handler exiting")
-	delete(sessions, session.Id)
-}
 
-type Session struct {
-	Id         string
-	socket     *websocket.Conn
-	snapClient *client.Client
-	jsonrpcCli *rpc.Client
 }
 
 func (s *Session) Run() {
-
+	defer s.socket.Close()
 	done := make(chan struct{})
 	go func(done chan struct{}) {
 		ticker := time.NewTicker(time.Second)
@@ -102,26 +184,9 @@ func (s *Session) Run() {
 				ticker.Stop()
 				return
 			}
-			log.Printf("Heartbeat took %s", recv.Sub(sent))
+			log.Printf("Heartbeat to node %s took %s", s.Name, recv.Sub(sent))
 		}
 		close(done)
-	}(done)
-
-	go func(done chan struct{}) {
-		ticker := time.NewTicker(time.Second * 5)
-		for {
-			select {
-			case <-ticker.C:
-				resp := s.snapClient.GetPlugins(true)
-				for _, plugin := range resp.LoadedPlugins {
-					log.Printf("found plugin %s", plugin.Name)
-				}
-			case <-done:
-				log.Printf("stopping plugin list")
-				ticker.Stop()
-				return
-			}
-		}
 	}(done)
 
 	<-done

--- a/mgmt/rest/ws_client/server/server.go
+++ b/mgmt/rest/ws_client/server/server.go
@@ -107,7 +107,6 @@ func nodesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func proxyHandler(w http.ResponseWriter, r *http.Request) {
-	log.Printf("handling proxy request")
 	query := r.URL.Query()
 	node := query.Get("proxy_node")
 
@@ -138,7 +137,6 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func websocketHandler(ws *websocket.Conn) {
-	log.Printf("Handler starting")
 	c := jsonrpc.NewClient(ws)
 	hc := &http.Client{
 		Transport: &wsRoundTripper{c: c},
@@ -165,8 +163,6 @@ func websocketHandler(ws *websocket.Conn) {
 	sessionsStore.Put(session.Name, session)
 	defer sessionsStore.Delete(session.Name)
 	session.Run()
-	log.Printf("Handler exiting")
-
 }
 
 func (s *Session) Run() {
@@ -184,7 +180,6 @@ func (s *Session) Run() {
 				ticker.Stop()
 				return
 			}
-			log.Printf("Heartbeat to node %s took %s", s.Name, recv.Sub(sent))
 		}
 		close(done)
 	}(done)

--- a/mgmt/rest/ws_client/ws_client.go
+++ b/mgmt/rest/ws_client/ws_client.go
@@ -1,0 +1,81 @@
+package ws_client
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"time"
+
+	"github.com/intelsdi-x/snap/mgmt/rest"
+	"golang.org/x/net/websocket"
+)
+
+type fakeWriter struct {
+	status int
+	Body   bytes.Buffer
+	header http.Header
+}
+
+func (w *fakeWriter) Write(b []byte) (int, error) {
+	log.Printf("writeHeader: %d", w.status)
+	w.Body.WriteString("HTTP/1.1 200 OK\n")
+	w.Body.WriteString(fmt.Sprintf("Content-Length: %d\n", len(b)))
+	w.Body.WriteString("\n")
+	return w.Body.Write(b)
+}
+
+func (w *fakeWriter) WriteHeader(code int) {
+	w.status = code
+}
+
+func (w *fakeWriter) Header() http.Header {
+	return w.header
+}
+
+type WsClient struct {
+	Server *rest.Server
+	ws     *websocket.Conn
+}
+
+func New(remoteAddr string, server *rest.Server) {
+	origin := "http://localhost/"
+	ws, err := websocket.Dial(remoteAddr, "", origin)
+	if err != nil {
+		log.Fatal(err)
+	}
+	scow := &SnapClientOverWebsocket{Server: server}
+	rpc.Register(scow)
+	log.Println("starting jsonrcp server")
+	go jsonrpc.ServeConn(ws)
+	log.Println("jsonrpc server started.")
+}
+
+type SnapClientOverWebsocket struct {
+	Server *rest.Server
+}
+
+type WsClientPayload struct {
+	Data []byte
+}
+
+func (s *SnapClientOverWebsocket) Handle(r WsClientPayload, resp *WsClientPayload) error {
+	log.Println("handling jsonrpc request")
+	req, err := http.ReadRequest(bufio.NewReader(bytes.NewBuffer(r.Data)))
+	if err != nil {
+		return err
+	}
+	writer := &fakeWriter{header: make(http.Header)}
+	s.Server.ServeHTTP(writer, req)
+	resp.Data = writer.Body.Bytes()
+	return nil
+}
+
+func (s *SnapClientOverWebsocket) Heartbeat(t time.Time, r *time.Time) error {
+	log.Printf("recieved heartbeat.  Delay %s", time.Since(t))
+	*r = time.Now()
+	return nil
+}

--- a/mgmt/rest/ws_client/ws_client.go
+++ b/mgmt/rest/ws_client/ws_client.go
@@ -37,9 +37,10 @@ func (w *fakeWriter) Header() http.Header {
 	return w.header
 }
 
-func New(remoteAddr string, server *rest.Server) *SnapClientOverWebsocket {
+func New(remoteAddr, name string, server *rest.Server) *SnapClientOverWebsocket {
 	return &SnapClientOverWebsocket{
 		Server:     server,
+		name:       name,
 		remoteAddr: remoteAddr,
 	}
 }
@@ -48,6 +49,7 @@ type SnapClientOverWebsocket struct {
 	remoteAddr string
 	Server     *rest.Server
 	Socket     *websocket.Conn
+	name       string
 }
 
 type WsClientPayload struct {

--- a/mgmt/rest/ws_client/ws_client.go
+++ b/mgmt/rest/ws_client/ws_client.go
@@ -88,6 +88,11 @@ func (s *SnapClientOverWebsocket) Heartbeat(t time.Time, r *time.Time) error {
 	*r = time.Now()
 	return nil
 }
+func (s *SnapClientOverWebsocket) Metadata(id string, meta *map[string]string) error {
+	*meta = map[string]string{"name": s.name}
+
+	return nil
+}
 
 func (s *SnapClientOverWebsocket) Stop() {
 	s.Socket.Close()

--- a/snapd.go
+++ b/snapd.go
@@ -361,7 +361,7 @@ func action(ctx *cli.Context) error {
 		coreModules = append(coreModules, r)
 		log.Info("REST API is enabled")
 		if cfg.RestAPI.WsServer != "" {
-			w := ws_client.New(cfg.RestAPI.WsServer, r)
+			w := ws_client.New(cfg.RestAPI.WsServer, cfg.Tribe.Name, r)
 			coreModules = append(coreModules, w)
 		}
 	} else {

--- a/snapd.go
+++ b/snapd.go
@@ -359,8 +359,11 @@ func action(ctx *cli.Context) error {
 		}
 		go monitorErrors(r.Err())
 		coreModules = append(coreModules, r)
-		ws_client.New("ws://localhost:7000/ws", r)
 		log.Info("REST API is enabled")
+		if cfg.RestAPI.WsServer != "" {
+			w := ws_client.New(cfg.RestAPI.WsServer, r)
+			coreModules = append(coreModules, w)
+		}
 	} else {
 		log.Info("REST API is disabled")
 	}
@@ -771,6 +774,7 @@ func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 	cfg.RestAPI.RestKey = setStringVal(cfg.RestAPI.RestKey, ctx, "rest-key")
 	cfg.RestAPI.RestAuth = setBoolVal(cfg.RestAPI.RestAuth, ctx, "rest-auth")
 	cfg.RestAPI.RestAuthPassword = setStringVal(cfg.RestAPI.RestAuthPassword, ctx, "rest-auth-pwd")
+	cfg.RestAPI.WsServer = setStringVal(cfg.RestAPI.WsServer, ctx, "ws-server")
 	// next for the scheduler related flags
 	cfg.Scheduler.WorkManagerQueueSize = setUIntVal(cfg.Scheduler.WorkManagerQueueSize, ctx, "work-manager-queue-size")
 	cfg.Scheduler.WorkManagerPoolSize = setUIntVal(cfg.Scheduler.WorkManagerPoolSize, ctx, "work-manager-pool-size")

--- a/snapd.go
+++ b/snapd.go
@@ -43,6 +43,7 @@ import (
 	"github.com/intelsdi-x/snap/control"
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/mgmt/rest"
+	"github.com/intelsdi-x/snap/mgmt/rest/ws_client"
 	"github.com/intelsdi-x/snap/mgmt/tribe"
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
 	"github.com/intelsdi-x/snap/pkg/cfgfile"
@@ -358,6 +359,7 @@ func action(ctx *cli.Context) error {
 		}
 		go monitorErrors(r.Err())
 		coreModules = append(coreModules, r)
+		ws_client.New("ws://localhost:7000/ws", r)
 		log.Info("REST API is enabled")
 	} else {
 		log.Info("REST API is disabled")


### PR DESCRIPTION
The snap agent initiates a websocket connection to a server.
We then use this websocket as a transport for the remote server
to send REST calls.

To minimize code changes to Snap, we are encapsulating the REST
client HTTP calls inside JSONRPC calls over  websocket, which
is over a HTTP interface.  With this approach the "client", which
is the websocket server, can use the native snap client library
to manage the node.

There is definitely cleaner ways to implement all of this, but
this demonstrates the concept of a client with a server initiated
connection nicely.

A basic reference server is provide in mgmt/rest/ws_client/server
